### PR TITLE
fix: prevent path traversal in GetFile endpoint

### DIFF
--- a/api/v1/file_controller.go
+++ b/api/v1/file_controller.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"io/ioutil"
+	"path/filepath"
 	"net/http"
 	"strings"
 
@@ -18,7 +19,20 @@ import (
 func GetFile(c *gin.Context) {
 	fileName := c.Param("fileName")
 	log.Logger.Info(fileName)
-	data, _ := ioutil.ReadFile(config.GetConfig().StaticPath.FilePath + fileName)
+
+	// Prevent path traversal by extracting only the base filename
+	fileName = filepath.Base(fileName)
+	if fileName == "." || fileName == "/" {
+		c.JSON(http.StatusBadRequest, response.FailMsg("invalid file name"))
+		return
+	}
+
+	filePath := filepath.Join(config.GetConfig().StaticPath.FilePath, fileName)
+	data, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		c.JSON(http.StatusNotFound, response.FailMsg("file not found"))
+		return
+	}
 	c.Writer.Write(data)
 }
 


### PR DESCRIPTION
## Summary

Prevent path traversal in the `GetFile` endpoint by sanitizing the filename parameter.

## Problem

The `GetFile` function in `api/v1/file_controller.go` directly concatenates the user-supplied `fileName` parameter with the base file path without any sanitization:

```go
func GetFile(c *gin.Context) {
    fileName := c.Param("fileName")
    data, _ := ioutil.ReadFile(config.GetConfig().StaticPath.FilePath + fileName)
    c.Writer.Write(data)
}
```

An attacker can read arbitrary files on the server by sending requests with path traversal sequences:
- `GET /file/../../etc/passwd` → reads `/etc/passwd`
- `GET /file/../../config.toml` → reads server configuration (may contain credentials)

Additionally, the error from `ioutil.ReadFile` is silently discarded (`_`), so failed reads return empty responses without proper error handling.

## Fix

1. Use `filepath.Base(fileName)` to strip any directory components, preventing path traversal
2. Use `filepath.Join` instead of string concatenation for safe path construction
3. Add proper error handling for file not found cases

## Impact

- **Type**: Path Traversal / Arbitrary File Read (CWE-22)
- **Affected endpoint**: `GET /file/:fileName`
- **Risk**: Read any file on the server including configs, credentials, and system files
- **OWASP**: A01:2021 — Broken Access Control